### PR TITLE
fix(CODEOWNERS): limit codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @nodejs/web
+* @nodejs/nodejs-website @nodejs/web-infra


### PR DESCRIPTION
Apparently, the entire web team does not have access to write to this repository, so this narrows the CODEOWNERS to the subteams that do.