### PR TITLE
Sync GOVERNANCE.md to one in website repo

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,169 +1,54 @@
 # Node.js Web Team Governance
 
-This document describes the governance structure and processes for the Node.js Web Team.
-
-## Overview
-
-The Node.js Web Team (`@nodejs/web`) maintains Node.js's web presence and related projects through four specialized subteams, each with distinct responsibilities and expertise.
-
-## Team Structure
-
-### 1. Node.js Website Team (`@nodejs/nodejs-website`)
-
-**Responsibilities:**
-
-- Day-to-day technical development of [nodejs.org](https://nodejs.org)
-- Feature development and enhancement
-- Website component creation
-- Security issue resolution
-- Operational maintenance
-
-The Website Team maintains final decision authority on website issues and pull requests, in accordance with the project's Contribution Guidelines, Collaborator Guidelines, Code of Conduct, and overall Node.js governance.
-
-### 2. Node.js Web Infrastructure Team (`@nodejs/web-infra`)
-
-**Responsibilities:**
-
-- Maintenance of CI/CD pipelines for web projects
-- Management of web infrastructure providers\*
-- Establishment of technical standards and best practices
-- Infrastructure access management
-
-\*Note: This team manages infrastructure specific to the Website (e.g., Vercel). Other shared infrastructure (e.g., Cloudflare) may be managed by other teams such as the Node.js Build WG.
-
-### 3. Node.js Web Standards Team (`@nodejs/web-standards`)
-
-**Responsibilities:**
-
-- Advisory role on web standards (e.g., Ecma262)
-- Consultation for Node.js Collaborators, TSC, and Web Team on standards-related matters
-- Guidance on standards compliance
-
-This team consists of Node.js Collaborators and external experts with significant web standards experience.
-
-### 4. Node.js UX & Design Team (`@nodejs/ux-and-design`)
-
-**Responsibilities:**
-
-- Advisory role on UX and design matters
-- Development of design guidelines and best practices
-- Consultation on:
-  - CSS implementation
-  - Accessibility standards
-  - User experience flows
-  - Component design
-
-This team consists of Node.js Collaborators and external experts with UX and design expertise.
-
-## Membership
-
-Team membership is not time-limited, and there is no fixed size for any subteam.
-
-### Website Team Membership
-
-Members are nominated according to the [Collaborator Guide](https://github.com/nodejs/nodejs.org/blob/main/docs/collaborator-guide.md#becoming-a-collaborator) in the nodejs.org repository. Upon successful nomination, new members should add themselves to [MEMBERS.md](MEMBERS.md) via pull request.
-
-### Web Infrastructure Team Membership
-
-Members are nominated by:
-
-- Node.js Technical Steering Committee (TSC)
-- Node.js Build WG, following their Collaborator Guidelines
-- Existing Node.js Web Team members (recommendation only)
-
-### Web Standards Team Membership
-
-Members are nominated by:
-
-- Node.js Technical Steering Committee (TSC)
-- Existing Node.js Web Team members (recommendation only)
-
-### UX & Design Team Membership
-
-Members are nominated by:
-
-- Node.js Technical Steering Committee (TSC)
-- Existing Node.js Web Team members (recommendation only)
-
-### Current Members
-
-The current list of all Web Team members across all subteams is maintained in [MEMBERS.md](MEMBERS.md).
-
-## Governance
+The Node.js Web Team (@nodejs/web) is a team in the Node.js Project that is composed by a set of subteams. Each containing specific responsibilities and goals.
 
 ### TSC Oversight
 
-Any website change that expresses a position about a global event or group of people requires explicit [TSC](https://github.com/nodejs/TSC/blob/main/TSC-Charter.md#section-4-responsibilities-of-the-tsc) approval through one of these methods:
+Any website change that expresses a position about a global event or group of people requires explicit
+[TSC](https://github.com/nodejs/TSC/blob/main/TSC-Charter.md#section-4-responsibilities-of-the-tsc)
+approval. This can be obtained by pinging `@nodejs/tsc` and receive no objections after seven days,
+or by sending an email to `tsc@iojs.org` and receive at least one approval and no objections after seven days.
 
-- Pinging `@nodejs/tsc` and receiving no objections after seven days
-- Emailing `tsc@iojs.org` and receiving at least one approval with no objections after seven days
+### Node.js Website Team (`@nodejs/nodejs-website`)
 
-### Team Meetings
+The Node.js Website Team is responsible for the day-to-day technical development of the Node.js Website. This is primarily the development of the website itself, adding new features, pages and components, but also fixing any security issues in the website code, handling operational maintenance, and so on.
 
-- Individual subteams may hold meetings as needed
-- Cross-team coordination happens through issues in this repository
-- Governance discussions occur through repository issues and relevant communication channels
+The maintainers on the Node.js Website Team are responsible for steering the technical direction of the Node.js Website, and reserve the right to make final decisions on any issues or pull requests, in line with the Contribution Guidelines, Collaborator Guidelines, the Code of Conduct and the overall Governance premises of the Node.js project.
 
-Any community member or contributor can request discussion topics by creating GitHub Issues. Team members can contribute to discussions by participating in issue threads.
+Members of this team are nominated through the guidelines provided in the [Contributing Guidelines](https://github.com/nodejs/nodejs.org/blob/main/CONTRIBUTING.md#becoming-a-collaborator) within the [nodejs.org](https://github.com/nodejs/nodejs.org) repository. After a passed nomination, members should submit a PR to add themselves to the list of current members, shown below.
 
-### Consensus Seeking Process
+### Node.js Web Infra Team (`@nodejs/web-infra`)
 
-The Web Team follows a [Consensus Seeking](http://en.wikipedia.org/wiki/Consensus-seeking_decision-making) decision-making model for governance matters:
+The Node.js Web Infra Team is responsible for maintaining the Infrastructure relating to Node.js's Web Presence. The Node.js Web Infra team has the responsibilities of:
 
-- For subteam-specific decisions, each subteam follows their established processes
-- For cross-team matters, consensus is sought through GitHub Issue discussions with appropriate input from affected subteams
+- Maintaining CI/CD pipelines related to Web Infrastructure
+- Maintaining our Infrastructure Providers\*
+- Have technical ownership on best-standards and best-practices for our Web Infrastructure (such as Web Frameworks that we use)
 
-### Pull Request Guidelines
+Web Infra Team members should have access to be able to maintain the services mentioned above.
 
-For pull requests to the governance repository:
+Members of this team are nominated either by the Node.js Technical Steering Committee (TSC) or the Node.js Build WG and follow the guidelines provided in the Collaborator Guidelines of the Node.js Build WG. Note that members of the Node.js Web Team might also recommend people for nomination.
 
-**Items requiring consensus seeking:**
+\* This team has access to infrastructure providers directly related to the Website only, such as Vercel. Other providers that are shared beyond the Website may be controlled by other teams (for example, the Node.js Build WG owns Cloudflare).
 
-- Governance changes
-- Significant process modifications
+### Node.js Web Standards Team (`@nodejs/web-standards`)
 
-**Items that may be merged with reasonable review time and no dissent:**
+The Node.js Web Standards Team is composed of Node.js Collaborators and External Collaborators that have extensive experience or expertisè on Web Standards, such as Ecma262. The Standards Team is responsible for guiding and serving as points of contact when either Node.js Collaborators, the Node.js Technical Steering Committee (TSC), or the Web Team, requires assistance or guidance regarding Web Standards.
 
-- Errata fixes
-- Editorial changes
-- Meeting minutes
-- Team member updates in MEMBERS.md
-- Documentation fixes
-- Process clarifications
+Members of this team are nominated by the Node.js Technical Steering Committee (TSC). Note that members of the Node.js Web Team might also recommend people for nomination.
 
-## Interoperability
+### Node.js UX & Design Team (`@nodejs/ux-and-design`)
 
-The four Node.js Web Team subteams collaborate with complementary roles:
+The Node.js UX & Design Team is composed of Node.js Collaborators and External Collaborators that have experience or expertisè with UX & Design. The UX & Design Team is responsible for guiding and serving as points of contact when members of the Node.js Web Team require assistance or guidance regarding UX & Design.
 
-- **Web Infrastructure Team**: Manages technical infrastructure and CI/CD
-- **Website Team**: Handles day-to-day development
-- **UX and Design Team**: Provides design guidance
-- **Web Standards Team**: Advises on web technologies and standards compliance
+Often members of this team will collaborate on providing best practices and guidelines for the Node.js Website, on matters of UX & Design. Members of this team are also responsible for providing feedback on the Node.js Website, and providing feedback on the Node.js Website's design. (For example, when a discussion arises regarding best practices on topics such as CSS, accessibility, UX flows and intent, or component design, the UX & Design Team has a say on the matter).
 
-Together, these teams work to deliver the best possible web experience for the Node.js community and users.
+Members of this team are nominated by the Node.js Technical Steering Committee (TSC). Note that members of the Node.js Web Team might also recommend people for nomination.
 
-## Developer's Certificate of Origin 1.1
+## The Interoperability of the Node.js Web Team
 
-By making a contribution to this project, I certify that:
+As seen above, the different teams under the Node.js Web Team umbrella are responsible for having the oversight on different aspects of Node.js's Web-related projects. However, it is important to note that the Node.js Web Team is not a set of siloed teams, but rather a set of teams that work together to achieve the same goal: Providing the best Web Experience for Node.js.
 
-- (a) The contribution was created in whole or in part by me and I
-  have the right to submit it under the open source license
-  indicated in the file; or
+Following this line of thought, the Web Infra Team is responsible for the technical aspects of the Node.js Website (Infrastructure, Framework, CI/CD, etc); The Website Team is responsible for the day-to-day development of the Node.js Website; The UX and Design Team advise on Design Matters and the Web Standards Team advise on best-practices for Web APIs and Web Technologies/Standards.
 
-- (b) The contribution is based upon previous work that, to the best
-  of my knowledge, is covered under an appropriate open source
-  license and I have the right under that license to submit that
-  work with modifications, whether created in whole or in part
-  by me, under the same open source license (unless I am
-  permitted to submit under a different license), as indicated
-  in the file; or
-
-- (c) The contribution was provided directly to me by some other
-  person who certified (a), (b) or (c) and I have not modified
-  it.
-
-- (d) I understand and agree that this project and the contribution
-  are public and that a record of the contribution (including all
-  personal information I submit with it, including my sign-off) is
-  maintained indefinitely and may be redistributed consistent with
-  this project or the open source license(s) involved.
+But above all, the Web Team should work together to better the Web Experience for Node.js, aiming to provide the best experience for Node.js users.


### PR DESCRIPTION
This syncs the GOVERNANCE.md file in this repository to the one present [in the website repo's](https://github.com/nodejs/nodejs.org/blob/2a5d26feb99da533fd0280486510163fa30d4322/GOVERNANCE.md) with two changes:

1. Reference to the collaborator's guide updated to be a link to the collaborator's guide (to the one in the website repo still)
2. List of website team members removed since they're already in [MEMBERS.md](https://github.com/nodejs/web-team/blob/c908153109912f9ae067444255b5e46818f2e096/GOVERNANCE.md).