### PR TITLE
feat(gov): add @nodejs/nodejs-website onboarding

### DIFF
--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -1,0 +1,17 @@
+# Onboarding Guide
+
+This guide outlines the steps required to onboard a new member to the @nodejs/web team and its subteams.
+
+## General Requirements
+
+Before onboarding the **Nominee**, ensure they have read and understand [the governance of the @nodejs/web team](./GOVERNANCE.md).
+
+- [ ] If the **Nominee** is not yet part of the @nodejs GitHub organization, verify that they have two-factor authentication enabled. Membership cannot be granted without it.
+
+## @nodejs/nodejs-website Onboarding
+
+Before onboarding the **Nominee**, ensure they have read and understand the [Collaborator Guide](https://github.com/nodejs/nodejs.org/blob/main/docs/collaborator-guide.md) of the @nodejs/nodejs-website team.
+
+- [ ] The **Nominee** should submit a pull request to this repository, adding themselves to [the MEMBERS.md file](./MEMBERS.md). This pull request should also include this onboarding checklist.
+- [ ] Add the **Nominee** to the @nodejs/nodejs-website team on GitHub.
+- [ ] Grant the **Nominee** "Edit" access to the [Figma design file](https://www.figma.com/file/a10cjjw3MzvRQMPT9FP3xz).


### PR DESCRIPTION
This PR adds the onboarding guide for @nodejs/nodejs-website, similar to #17.