### PR TITLE
ci: set 3-day cooldown for Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,5 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 3


### PR DESCRIPTION
Resolves https://github.com/nodejs/web-team/issues/25