### PR TITLE
ci: enable Dependabot updates for shared actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,9 @@
 version: 2
 updates:
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directories:
+      - /
+      - /actions/*
     schedule:
       interval: "monthly"
     cooldown:

--- a/actions/notify-on-push/action.yml
+++ b/actions/notify-on-push/action.yml
@@ -10,7 +10,7 @@ runs:
   using: "composite"
   steps:
     - name: Slack Notification
-      uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661
+      uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661 # v2.3.3
       env:
         SLACK_COLOR: "#DE512A"
         SLACK_ICON: https://github.com/nodejs.png?size=48


### PR DESCRIPTION
cc @nodejs/web-infra 

https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#directories-or-directory--

Dependabot looks in `./.github/workflows/*.y(a)ml`, as well as `./action.y(a)ml` for each directory provided in the config.