### PR TITLE
chore(members): remove @richardlau

### DIFF
--- a/MEMBERS.md
+++ b/MEMBERS.md
@@ -26,7 +26,6 @@
 - [@MattIPv4](https://github.com/MattIPv4) - **Matt Cowley** (he/him)
 - [@MoLow](https://github.com/MoLow) - **Moshe Atlow** (he/him)
 - [@ovflowd](https://github.com/ovflowd) - **Claudio Wunder** (they/them)
-- [@richardlau](https://github.com/richardlau) - **Richard Lau**
 
 ## Node.js Web Standards Team (`@nodejs/web-standards`)
 


### PR DESCRIPTION
I just checked the team list, and noticed @richardlau is no longer on it.

@richardlau was this intentional?