### PR TITLE
chore(members): remove inactive members

### DIFF
--- a/MEMBERS.md
+++ b/MEMBERS.md
@@ -13,7 +13,6 @@
 - [@canerakdas](https://github.com/canerakdas) - **Caner Akdas**
 - [@dario-piotrowicz](https://github.com/dario-piotrowicz) - **Dario Piotrowicz**
 - [@Harkunwar](https://github.com/Harkunwar) - **Harkunwar Kochar** (he/him)
-- [@HinataKah0](https://github.com/HinataKah0) - **HinataKah0** (he/him)
 - [@manishprivet](https://github.com/manishprivet) - **Manish Kumar** (he/him)
 - [@mikeesto](https://github.com/mikeesto) - **Michael Esteban** (he/him)
 - [@ovflowd](https://github.com/ovflowd) - **Claudio Wunder** (they/them)


### PR DESCRIPTION
cc @nodejs/web-admins

Closes #74

---

~~Before this lands, @HinataKah0 should be removed from the @nodejs/nodejs-website team. Because this is their only team in the organization, they may also need to be removed from the entire organization by @nodejs/tsc.~~ Done