### PR TITLE
governance: add trial period for new web-infra members

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -29,6 +29,21 @@ Web Infra Team members should have access to maintain the services mentioned abo
 
 Members of this team are nominated either by the Node.js Technical Steering Committee (TSC) or the Node.js Build WG and follow the guidelines provided in the Collaborator Guidelines of the Node.js Build WG. Current members of the Node.js Web Infra Team may also nominate individuals.
 
+#### Trial Period for New Members
+
+Upon acceptance, new members of the Web Infra Team enter a **trial period of 3 months** with limited access to infrastructure services. The purpose of this trial period is to ensure new members can demonstrate competence and trustworthiness in managing critical infrastructure before being granted elevated privileges.
+
+During the trial period, new members receive the following reduced permissions:
+
+- **Cloudflare**: Read-only access (day-to-day operations generally do not require manual changes)
+- **Vercel**: Viewer-level access (sufficient to review deployments, check logs, and monitor project status)
+- **Sentry, Crowdin, Atlassian Statuspage**: Read-only or limited access
+- **1Password**: Access is not granted during the trial period; credentials may be shared on a case-by-case basis by an existing member for specific tasks
+
+New members should use the trial period to familiarize themselves with the team's infrastructure, processes, and incident response procedures. Existing team members are expected to actively mentor and support new members throughout this period.
+
+At the end of the trial period, existing Web Infra Team members will assess the new member's readiness for full access, based on demonstrated competence and trust. Full access may be granted earlier by consensus of existing team members if the member demonstrates exceptional competence and trustworthiness. Conversely, the trial period may be extended if the team determines that additional time is needed.
+
 \* This team has access to infrastructure providers directly related to the Website only, such as Vercel. Other providers that are shared beyond the Website may be controlled by other teams (for example, the Node.js Build WG owns Cloudflare).
 
 When considering new members, approvers are primarily concerned with **competence** and **trust**. The [language within the Build WG pertaining to competence and trust](https://github.com/nodejs/build/blob/main/GOVERNANCE.md#wg-membership) applies here. The following is repeated, for emphasis:

--- a/PERMISSIONS.md
+++ b/PERMISSIONS.md
@@ -29,6 +29,23 @@
 | **[Sentry][]**               | -                                  | -           | -                      | Admin             | Admin              |                                                                                                                                                                        |
 | **[Vercel][]**               | -                                  | -           | -                      | Developer         | Owner              | Along with individual access, credentials for a user with elevated exist in 1Password.                                                                                 |
 
+### Trial Period Permissions for New Web Infra Members
+
+As outlined in [GOVERNANCE.md](GOVERNANCE.md), new members of the @nodejs/web-infra team undergo a **3-month trial period** with reduced permissions before receiving full access. The table below shows the access levels granted during the trial period compared to the full access levels shown above.
+
+| Service                      | Trial Period Access | Full Access (post-trial) | Notes                                                                                              |
+| ---------------------------- | ------------------- | ------------------------ | -------------------------------------------------------------------------------------------------- |
+| **[1Password][]**            | -                   | Admin                    | Not granted during trial; credentials shared on a case-by-case basis by an existing member.        |
+| **[Atlassian Statuspage][]** | Read                | App Admin                | Public status page is accessible to everyone; management access is granted after trial.             |
+| **[Chromatic][]**            | Read                | Admin                    | Read access available via GitHub authentication.                                                   |
+| **[Cloudflare][]**           | Read                | Read                     | Read-only access is sufficient for day-to-day; elevated access may be granted on a case-by-case basis post-trial. |
+| **[Crowdin][]**              | Read                | Admin                    | Read access to review translations; admin access after trial.                                      |
+| **[Sentry][]**               | Read                | Admin                    | Read access to view error reports and logs; admin access after trial.                               |
+| **[Vercel][]**               | Viewer              | Developer                | Viewer access allows reviewing deployments and checking logs; Developer access after trial.         |
+
+> [!NOTE]
+> GitHub repository permissions are **not** affected by the trial period. New members receive the same repository-level access as all @nodejs/web-infra members from day one.
+
 ## Access Tokens & Automations
 
 | Secret Name                | Display Name            | Platform(s) / Location(s)                                              | Associated Project(s)                     | Access Level | Expiry | Notes                                       |

--- a/onboarding/web-infra.md
+++ b/onboarding/web-infra.md
@@ -5,20 +5,22 @@ This document is an outline of the tasks necessary to onboard a new member of th
 Please note these tasks should only be performed after an individual's nomination has passed.
 To start the nomination process, see [GOVERNANCE.md](../GOVERNANCE.md).
 
-## Tasks
+## Phase 1: Trial Period Access
+
+New members begin with a **3-month trial period** and receive limited access to infrastructure services. See [GOVERNANCE.md](../GOVERNANCE.md) for details on the trial period policy.
+
+### Tasks
 
 - [ ] Add the **Nominee** to the @nodejs/web-infra team on GitHub.
-- [ ] The **Nominee** should open an issue in [nodejs/admin](https://github.com/nodejs/admin) requesting access to the Web Infra 1Password vault.
-- [ ] Grant the **Nominee** access to Sentry.
-  - [ ] The **Nominee** should enable physical or passkey 2FA on their Sentry account.
-- [ ] Grant the **Nominee** access to Vercel.
-  - [ ] The nominee should enable physical or passkey 2FA on their Vercel account.
+- [ ] Grant the **Nominee** _Viewer_ access to Vercel.
+  - [ ] The Nominee should enable physical or passkey 2FA on their Vercel account.
+- [ ] Grant the **Nominee** _Read-only_ access to Sentry.
+  - [ ] The Nominee should enable physical or passkey 2FA on their Sentry account.
+- [ ] Grant the **Nominee** _Read-only_ access to Crowdin.
+- [ ] Grant the **Nominee** _Read-only_ access to the Node.js Status Page.
 - [ ] The **Nominee** should add their email to the following aliases (by opening a PR in [nodejs/email](https://github.com/nodejs/email)):
   - [ ] [`nodejs-crowdin`](https://github.com/nodejs/email/blob/main/iojs.org/aliases.json#L174)
   - [ ] [`nodejs-vercel`](https://github.com/nodejs/email/blob/main/iojs.org/aliases.json#L241)
-- [ ] Grant the **Nominee** access to Crowdin.
-- [ ] Grant the **Nominee** access to Search Console.
-- [ ] Grant the **Nominee** access to the Node.js Status Page.
 - [ ] An OpenJS Slack Admin should add their Slack account to the `nodejs-website-team` team.
 - [ ] Add the **Nominee** to the following OpenJS Slack channels:
   - [ ] `#nodejs-website`
@@ -32,6 +34,22 @@ To start the nomination process, see [GOVERNANCE.md](../GOVERNANCE.md).
 - [ ] The **Nominee** should have some form of physical 2FA (i.e. Yubikey) or passkey enabled on their GitHub account.
 - [ ] The **Nominee** should have any SSH or GPG key attached to their GitHub account have passphrases and/or be stored on a physical 2FA device.
 - [ ] The **Nominee** should sign their Git commits.
+
+## Phase 2: Full Access (Post-Trial)
+
+After the trial period concludes (typically 3 months), existing Web Infra Team members will assess the new member's performance and trustworthiness. If the team agrees the member is ready, the following tasks should be completed to grant full access.
+
+> [!NOTE]
+> Full access may be granted earlier by consensus of existing team members. The trial period may also be extended if the team determines additional time is needed.
+
+### Tasks
+
+- [ ] The **Nominee** should open an issue in [nodejs/admin](https://github.com/nodejs/admin) requesting access to the Web Infra 1Password vault.
+- [ ] Elevate the **Nominee** to _Developer_ access on Vercel.
+- [ ] Elevate the **Nominee** to _Admin_ access on Sentry.
+- [ ] Elevate the **Nominee** to _Admin_ access on Crowdin.
+- [ ] Elevate the **Nominee** to _App Admin_ access on the Node.js Status Page.
+- [ ] Grant the **Nominee** access to Search Console.
 
 ## Notes
 


### PR DESCRIPTION
## Summary

This PR introduces a **trial period policy** for new members of the @nodejs/web-infra team, as proposed in #8.

New Web Infra Team members will undergo a **3-month trial period** with reduced permissions across infrastructure services before being granted full access. This ensures that new members can demonstrate competence and trustworthiness while minimizing risk to critical infrastructure.

## Changes

### `GOVERNANCE.md`

Added a new **"Trial Period for New Members"** subsection under the Web Infra Team section, defining:
- A 3-month trial period with limited access
- Specific reduced permission levels during the trial (read-only Cloudflare, Viewer on Vercel, read-only Sentry/Crowdin/Statuspage, no 1Password)
- Mentorship expectations for existing team members
- Criteria for concluding the trial (consensus-based assessment by existing members)
- Flexibility to shorten or extend the trial period

### `PERMISSIONS.md`

Added a new **"Trial Period Permissions for New Web Infra Members"** section with a comparison table showing trial vs. full access levels for each external service. Clarifies that GitHub repository permissions are unaffected by the trial.

### `onboarding/web-infra.md`

Restructured the onboarding checklist into two phases:
- **Phase 1: Trial Period Access** — initial limited permissions granted immediately upon acceptance
- **Phase 2: Full Access (Post-Trial)** — elevated permissions granted after successful completion of the trial period

## Motivation

As noted in #8, giving new members immediate full access to critical infrastructure services carries unnecessary risk. A trial period:
- Allows new members to build familiarity with processes and systems
- Gives existing members time to assess competence and trustworthiness
- Reduces potential impact of accidental misconfigurations
- Aligns with the emphasis on **competence and trust** already present in the governance model

Fixes #8